### PR TITLE
fix(config): remove obsolete card reference and update commit message…

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/Writerside/topics/event-server/event-server.topic
+++ b/Writerside/topics/event-server/event-server.topic
@@ -21,7 +21,6 @@
 
         <primary>
             <title>Kommende Events</title>
-            <card href="nether-event.md" badge="world"/>
             <card href="building-event.md" badge="creative"/>
         </primary>
 

--- a/Writerside/topics/event-server/event-server.topic
+++ b/Writerside/topics/event-server/event-server.topic
@@ -37,6 +37,7 @@
                 <card href="diamondevent.md" badge="top" summary="Mehr Informationen"/>
                 <card href="one-chunk.md" badge="container" summary="Mehr Informationen"/>
                 <card href="tilted.md" badge="cross-check" summary="Mehr Informationen"/>
+                <card href="nether-event.md" badge="cloud" summary="Mehr Informationen"/>
             </cards>
         </misc>
 


### PR DESCRIPTION
This pull request includes changes to the `.idea/vcs.xml` and `Writerside/topics/event-server/event-server.topic` files to improve commit message inspection and update event server topics.

Improvements to commit message inspection:

* [`.idea/vcs.xml`](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aR3-R10): Added a new `CommitMessageInspectionProfile` component with inspection tools for `CommitFormat` and `CommitNamingConvention` to ensure commit messages follow the specified format and naming conventions.

Updates to event server topics:

* [`Writerside/topics/event-server/event-server.topic`](diffhunk://#diff-2f050c1b5ae67b417147e45d7014d3f5c9c89934b787c9a2158830118954824aL24): Removed the card link to `nether-event.md` under the "Kommende Events" section.