### PR TITLE
fix(docs): update Senior Moderator & Moderator & Supporter list in ra…

### DIFF
--- a/Writerside/topics/general-server/ranks/ranks-overview.md
+++ b/Writerside/topics/general-server/ranks/ranks-overview.md
@@ -36,14 +36,14 @@ Was sie zu bedeuten haben und welche Aufgabe sie erfüllen, erfährst du auf die
 
 ## Teammitglieder {collapsible="true" default-state="collapsed" id="team-members"}
 
-| Rang                                  | Mitglieder                                                                                                                                                              |
-|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![Administrator](administrator.png)   | <ul><li>`CastCrafter`</li><li>`Keviro`</li><li>`NotAmmo`</li><li>`Twisti_Twixi`</li></ul>                                                                               |
-| ![Entwickler](developer.png)          | <ul><li>`TheBjoRedCraft`</li></ul>                                                                                                                                      |
-| ![Senior Moderator](sr-moderator.png) | <ul><li>`ImRuBiX232`</li></ul>                                                                                                                                          |
-| ![Moderator](moderator.png)           | <ul><li>`Alex_mhr`</li><li>`GesturesKing`</li><li>`Jo_field`</li><li>`MikeyLLP`</li><li>`RicTheCraft`</li><li>`xX_Monster`</li></ul>                                    |
-| ![Supporter](supporter.png)           | <ul><li>`BobbyCar2612`</li><li>`bringeis1`</li><li>`Koljav`</li><li>`Laluck98`</li><li>`Orangenlimo`</li><li>`Progeilo`</li><li>`Timonso`</li><li>`Qwoxelias`</li></ul> |
-| ![Builder](builder.png)               | <ul><li>`Speed_Marc`</li></ul>                                                                                                                                          |
+| Rang                                  | Mitglieder                                                                                                                                           |
+|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ![Administrator](administrator.png)   | <ul><li>`CastCrafter`</li><li>`Keviro`</li><li>`NotAmmo`</li><li>`Twisti_Twixi`</li></ul>                                                            |
+| ![Entwickler](developer.png)          | <ul><li>`TheBjoRedCraft`</li></ul>                                                                                                                   |
+| ![Senior Moderator](sr-moderator.png) | <ul><li>`ImRuBiX232`</li><li>`RicTheCraft`</li></ul>                                                                                                 |
+| ![Moderator](moderator.png)           | <ul><li>`Alex_mhr`</li><li>`GesturesKing`</li><li>`Jo_field`</li><li>`MikeyLLP`</li><li>`xX_Monster`</li><li>`Laluck98`</li></ul>                    |
+| ![Supporter](supporter.png)           | <ul><li>`BobbyCar2612`</li><li>`bringeis1`</li><li>`Koljav`</li><li>`Orangenlimo`</li><li>`Progeilo`</li><li>`Timonso`</li><li>`Qwoxelias`</li></ul> |
+| ![Builder](builder.png)               | <ul><li>`Speed_Marc`</li></ul>                                                                                                                       |
 
 ## Bewerbungen {collapsible="true" default-state="collapsed" id="team-application"}
 


### PR DESCRIPTION
This pull request includes updates to the team member ranks in the `Writerside/topics/general-server/ranks/ranks-overview.md` file. The changes primarily involve reorganization and updates to the lists of members for various ranks.

Updates to team member ranks:

* [`Writerside/topics/general-server/ranks/ranks-overview.md`](diffhunk://#diff-0f0da3bb97c5aba3fd40bf47a36f01fd79b8b72056fdbdf439c6c302eea70d60L40-R45): Updated the list of members for the `Senior Moderator`, `Moderator`, and `Supporter` ranks. Some members were moved between ranks and the lists were reorganized for clarity.