### PR TITLE
feat(event): add CraftAttack Cube Building event documentation and up…

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,8 +3,6 @@
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
       <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>

--- a/Writerside/ccs.tree
+++ b/Writerside/ccs.tree
@@ -67,6 +67,7 @@
             <toc-element topic="flatworld.md"/>
             <toc-element topic="stoneblock-event.md"/>
             <toc-element topic="anarchy-event.md"/>
+            <toc-element topic="craftattack-cube-building.md"/>
         </toc-element>
     </toc-element>
     <toc-element topic="clan-system.topic">

--- a/Writerside/labels.list
+++ b/Writerside/labels.list
@@ -97,6 +97,20 @@
     <secondary-label id="creative2-mc-version" name="1.21.4" color="purple">
         Das Event wird in der Minecraft Java Version 1.21.4 stattfinden.
     </secondary-label>
+    <secondary-label id="ca-cube-self-date" name="15.02.2025 - 22.02.2025" color="blue">Das Event
+        läuft
+        vom 15.02.2025 bis zum 22.02.2025.
+    </secondary-label>
+    <secondary-label id="ca-cube-self-mc-version" name="1.21.4/1.21.5" color="purple">
+        Das Event wird in der Minecraft Java Version 1.21.4 stattfinden.
+    </secondary-label>
+    <secondary-label id="ca-cube-all-date" name="27.04.2025 - 03.05.2025" color="blue">Das Event
+        läuft
+        vom 27.04.2025 bis zum 03.05.2025.
+    </secondary-label>
+    <secondary-label id="ca-cube-all-mc-version" name="1.21.4/1.21.5" color="purple">
+        Das Event wird in der Minecraft Java Version 1.21.4 stattfinden.
+    </secondary-label>
     <secondary-label id="nether-event-date" name="22.03.2025 - 24.03.2025" color="blue">Das Event
         läuft
         vom 22.03.2025 bis zum 24.03.2025.

--- a/Writerside/topics/event-server/events/craftattack-cube-building.md
+++ b/Writerside/topics/event-server/events/craftattack-cube-building.md
@@ -1,0 +1,69 @@
+<primary-label ref="event-running"/>
+<secondary-label ref="ca-cube-all-mc-version"/>
+<secondary-label ref="ca-cube-all-date"/>
+
+# CraftAttack Würfel Bau Event
+
+## Über das Event {id="general-info"}
+
+Das Streamer-Projekt **CraftAttack 12** neigt sich dem Ende. Das Problem ist: Das Bau-Projekt von CastCrafter, ein Würfel ist noch nicht fertig.
+In diesem Event, habt ihr die Möglichkeit, einen Teil des Würfels zu bauen.
+
+Das Ziel: Den CraftAttack würfel mithilfe der Community fertig zu stellen. **CastCrafter** wird am Ende des Events, die besten Würfel auswählen und diese in CratAttack nachbauen.
+Jeder baut seinen eigenen Würfel. Deinen Plot kannst du mit `/plot auto` claimen und mit `/plot home` jederzeit betreten.
+Wenn du mit einer Gruppe von Freunden bauen möchtest, kannst du andere Spieler mit `/plot trust <Spieler>` zu deinem Plot einladen.
+>
+> **Achtung:** Der Würfel muss die Maße `44x44x44` Blöcke haben. Das bedeutet, dass die Grundfläche 44x44 Blöcke groß ist und die Höhe 44 Blöcke beträgt.
+> 
+> {style="warning"}
+
+![thumbnail](ca-building-event.png){border-effect="rounded"}
+
+
+## Regeln {id="rules"}
+
+> Bei diesem Event gibt es keine Regeländerungen. \
+> Es gelten die allgemeinen Serverregeln, welche ihr [hier](rules.md) einsehen k&ouml;nnt.
+>
+> **Bitte macht euch vor der Teilnahme mit den Regeln vertraut!**
+>
+{style="note" title="Es gelten die allgemeinen Serverregeln!"}
+
+### Geänderte Mechaniken {id="changed-mechanics"}
+
+Um den Server stabil zu halten und den Supportaufwand zu minimieren, wurden für das Event einige Mechaniken geändert oder deaktiviert.
+
+- Der Nether und das End sind deaktiviert
+- Es stehen grundsätzlich nur Items zur Verfügung, die es auch "normal" gibt. Es können keine Custom Items z. B. aus dem Singleplayer genutzt werden
+- Entities wie Mobs, ItemFrames, ArmorStands und Villager sind deaktiviert
+
+### Teleportation {id="teleportation"}
+
+Du kannst dich mit dem Befehl `/plot home` jederzeit zu deinem Plot teleportieren.
+
+> **Achtung:** Um diesem Befehl zu nutzen, musst du einen Plot erstellt haben.
+>
+{style="note"}
+
+### VoiceChat {id="voicechat"}
+
+In diesem Event steht euch ein Ingame-VoiceChat zur Verfügung, über welchen ihr mit anderen Spielern sprechen könnt.
+
+Um den VoiceChat benutzen zu können, müsst ihr euch die SimpleVoiceChat Mod installieren.
+
+Den Download der Mod findet ihr hier: [SimpleVoiceChat](https://modrinth.com/plugin/simple-voice-chat)
+
+
+## Q&amp;A {id="q-a"}
+
+{collapsible="true" default-state="collapsed"}
+Welche Version von Minecraft wird benötigt? {id="event-mc-version"}
+: Das Event wird in der Version **1.21.4/5** stattfinden.
+
+Was passiert, wenn ich gegen die Regeln verstoße? {id="event-rules"}
+: Regelverstöße werden ernst genommen und können zum dauerhaften Ausschluss vom gesamten Server führen. Haltet euch
+bitte an die Regeln, um ein faires und spaßiges Event für alle zu gewährleisten und beachtet die Eventspezifischen Regeln für dieses Event!
+
+Kann man auch später noch dem Event beitreten? {id="event-join-later"}
+: Ja, auch wenn das Event bereits begonnen hat, kannst du jederzeit dem Event beitreten. Wenn allerdings die maximale
+Spieleranzahl erreicht ist, kann es sein, dass du dich in die Warteschlange einreihen musst.


### PR DESCRIPTION
This pull request introduces a new event, the "CraftAttack Würfel Bau Event," to the documentation and updates related files to include details about this event. Key changes include the addition of a new topic file with event details, updates to labels and table of contents, and minor cleanup in configuration files.

### Event Documentation Updates:
* Added a new topic file `Writerside/topics/event-server/events/craftattack-cube-building.md` to document the "CraftAttack Würfel Bau Event." This includes event details, rules, mechanics, teleportation options, voice chat setup, and a Q&A section.
* Updated `Writerside/ccs.tree` to include the new topic in the table of contents.
* Added new labels in `Writerside/labels.list` for event-specific dates and Minecraft versions, such as `ca-cube-self-date` and `ca-cube-all-mc-version`.

### Configuration Cleanup:
* Removed duplicate and redundant entries in `.idea/vcs.xml` to streamline the file.