### PR TITLE
Add documentation for new End Event

### DIFF
--- a/Writerside/labels.list
+++ b/Writerside/labels.list
@@ -140,6 +140,14 @@
         Das Event wird in der Minecraft Java Version 1.21.4 und 1.21.5 stattfinden.
     </secondary-label>
 
+    <secondary-label id="end-event-date" name="07.06.2025 - 09.06.2025" color="blue">Das Event
+        läuft
+        vom 07.06.2025 um 17:00 Uhr bis zum 09.06.2025 um 17:00 Uhr.
+    </secondary-label>
+    <secondary-label id="end-event-mc-version" name="1.21.4 &amp; 1.21.5" color="purple">
+        Das Event wird in der Minecraft Java Version 1.21.4 und 1.21.5 stattfinden.
+    </secondary-label>
+
 
     <secondary-label id="max-skill-level-50" name="Maximales Level: 50" color="blue">
         Das maximal erreichbare Level dieses Skills beträgt 50.

--- a/Writerside/topics/event-server/event-server.topic
+++ b/Writerside/topics/event-server/event-server.topic
@@ -22,6 +22,7 @@
         <primary>
             <title>Aktuelle Events</title>
             <card href="crafting-challenge.md" badge="network" summary="Mehr Informationen"/>
+            <card href="end-event.md" badge="cloud" summary="Mehr Informationen"/>
 
         </primary>
 

--- a/Writerside/topics/event-server/events/end-event.md
+++ b/Writerside/topics/event-server/events/end-event.md
@@ -1,0 +1,42 @@
+<primary-label ref="event-upcoming"/>
+<secondary-label ref="end-event-mc-version"/>
+<secondary-label ref="end-event-date"/>
+
+# End Event
+
+## Über das Event {id="general-info"}
+
+Ihr seid für 48 Stunden im End eingesperrt. Es gibt nur diese Dimension – keine Overworld, kein Nether!
+
+Erkundet neue Strukturen und bekämpft unbekannte Monster. Diese lassen Items fallen, mit denen ihr neue, bislang unbekannte Gegenstände craften könnt.
+
+## Regeln {id="rules"}
+
+<include from="../../reusablecontent/util.md" element-id="no-rules-changed" />
+
+## Befehle {id="commands"}
+
+`/tpa <Spieler>`
+: Schickt dem angegebenen Spieler eine Teleportationsanfrage, um sich zu ihm zu teleportieren.
+
+`/tpaaccept`
+: Akzeptiert eine eingehende Teleportanfrage.
+
+`/spawn` : Bringt dich zum Spawnpunkt zurück.
+
+`/back` : Bringt dich zu deinem vorherigen Standort.
+
+## Q&A {id="q-a"}
+
+{collapsible="true" default-state="collapsed"}
+Wann beginnt das Event? {id="event-date"}
+: Das Event läuft vom **07.06.2025 um 17:00 Uhr** bis zum **9.06.2025 um 17:00 Uhr**.
+
+Welche Version von Minecraft wird benötigt? {id="event-mc-version"}
+: Du benötigst die Version **1.21.4** oder **1.21.5**.
+
+Was passiert, wenn ich gegen die Regeln verstoße? {id="event-rules"}
+: Regelverstöße werden ernst genommen und können zum dauerhaften Ausschluss vom gesamten Server führen.
+
+Kann man auch später noch dem Event beitreten? {id="event-join-later"}
+: Ja, du kannst jederzeit teilnehmen, solange noch Plätze frei sind.


### PR DESCRIPTION
## Summary
- add labels for the End Event
- document the End Event with rules, commands and FAQ
- link the new page in the Event Server overview
- fix event state label and date formatting

## Testing
- `docker run --rm -v "$PWD":/opt/sources -e SOURCE_DIR=/opt/sources -e MODULE_INSTANCE=Writerside/hi -e OUTPUT_DIR=/opt/sources/output -e RUNNER=other jetbrains/writerside-builder:2025.04.8412 > /tmp/build.log && tail -n 20 /tmp/build.log` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684433c7b8748328a1c8ac2683663b24