### PR TITLE
fix: update primary label for desert event to reflect event status

### DIFF
--- a/Writerside/topics/event-server/events/desert-event.md
+++ b/Writerside/topics/event-server/events/desert-event.md
@@ -1,4 +1,4 @@
-<primary-label ref="event-running"/>
+<primary-label ref="event-held"/>
 <secondary-label ref="desert-event-mc-version"/>
 <secondary-label ref="desert-event-date"/>
 


### PR DESCRIPTION
Merge-After: 2025-08-24T15:55:00.000Z